### PR TITLE
Load type declaration files when using ts-node

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@mishguru/package-example",
+  "version": "1.0.0",
+  "description": "Example project to test out @mishguru/package",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "../bin/build",
+    "test": "../bin/test",
+    "lint": "../bin/lint",
+    "tidy": "../bin/tidy"
+  }
+}

--- a/example/src/index.spec.ts
+++ b/example/src/index.spec.ts
@@ -1,0 +1,7 @@
+import test from 'ava'
+
+import example from './index'
+
+test('should export a function', (t) => {
+  t.is(typeof example, 'function')
+})

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,0 +1,5 @@
+import fileExists from 'file-exists'
+
+export default function () {
+  console.log(fileExists('./index.ts'))
+}

--- a/example/src/types/file-exists.d.ts
+++ b/example/src/types/file-exists.d.ts
@@ -1,0 +1,3 @@
+declare module 'file-exists' {
+  export default function(filename: string): Promise<boolean>
+}

--- a/src/cmd/test.ts
+++ b/src/cmd/test.ts
@@ -15,7 +15,9 @@ const test = async () => {
   const args = process.argv.slice(2)
 
   if (USE_TSC) {
-    if (args.length > 0) {
+    const fileArgs = args.filter((arg) => arg.startsWith('-') === false)
+
+    if (fileArgs.length > 0) {
       avaPath = AVA_TSC_PATH
     } else {
       process.argv = []

--- a/src/config/tsconfig.ts
+++ b/src/config/tsconfig.ts
@@ -1,24 +1,43 @@
+import globby from 'globby'
+import { join, basename } from 'path'
+
 import { SRC_PATH, DIST_PATH } from '../shared/constants'
 
-const config = {
-  compilerOptions: {
-    baseUrl: '.',
-    declaration: true,
-    esModuleInterop: true,
-    module: 'commonjs',
-    moduleResolution: 'node',
-    noImplicitAny: true,
-    outDir: DIST_PATH,
-    resolveJsonModule: true,
-    sourceMap: true,
-    target: 'es2018',
-    paths: {
-      '*': ['node_modules/*', `${SRC_PATH}/types/*`],
+const D_TS_PATH = `./types/*.d.ts`
+
+const createTSConfig = (): string => {
+  const declarationFiles = globby.sync(D_TS_PATH, { cwd: SRC_PATH })
+
+  const paths: Record<string, string[]> = {
+    '*': ['node_modules/*', `${SRC_PATH}/types/*`],
+  }
+
+  for (const filepath of declarationFiles) {
+    const moduleName = basename(filepath)
+      .replace(/\.d\.ts$/, '')
+    paths[moduleName] = [join(SRC_PATH, filepath)]
+  }
+
+  const config = {
+    compilerOptions: {
+      baseUrl: '.',
+      declaration: true,
+      esModuleInterop: true,
+      module: 'commonjs',
+      moduleResolution: 'node',
+      noImplicitAny: true,
+      outDir: DIST_PATH,
+      resolveJsonModule: true,
+      sourceMap: true,
+      target: 'es2018',
+      paths,
     },
-  },
-  include: [`${SRC_PATH}/**/*`],
+    include: [`${SRC_PATH}/**/*`],
+  }
+
+  const configString = JSON.stringify(config, null, 2)
+
+  return configString
 }
 
-const tsconfigJSON = JSON.stringify(config, null, 2)
-
-export default tsconfigJSON
+export default createTSConfig

--- a/src/shim/ts-node.ts
+++ b/src/shim/ts-node.ts
@@ -3,7 +3,7 @@ import { mockWithContext } from 'unwire'
 
 import { SRC_PATH } from '../shared/constants'
 
-import tsconfigJSON from '../config/tsconfig'
+import createTSConfig from '../config/tsconfig'
 
 const TSCONFIG_PATH = join(dirname(resolve(SRC_PATH)), 'tsconfig.json')
 
@@ -22,7 +22,9 @@ mockWithContext('fs', require.resolve('typescript'), (fs) => ({
   },
   readFileSync: (path: string, options: object) => {
     if (path === TSCONFIG_PATH) {
-      return Buffer.from(tsconfigJSON, 'utf8')
+      const configString = createTSConfig()
+      const configBuffer = Buffer.from(configString, 'utf8')
+      return configBuffer
     }
     return fs.readFileSync(path, options)
   },

--- a/src/shim/tsc.ts
+++ b/src/shim/tsc.ts
@@ -2,7 +2,7 @@ import { join, dirname, resolve } from 'path'
 import { mockWithContext } from 'unwire'
 
 import { SRC_PATH } from '../shared/constants'
-import tsconfigJSON from '../config/tsconfig'
+import createTSConfig from '../config/tsconfig'
 
 const TSCONFIG_PATH = join(dirname(resolve(SRC_PATH)), 'tsconfig.json')
 
@@ -22,7 +22,9 @@ const start = async () => {
     },
     readFileSync: (path: string, options: object) => {
       if (path === TSCONFIG_PATH) {
-        return Buffer.from(tsconfigJSON, 'utf8')
+        const configString = createTSConfig()
+        const configBuffer = Buffer.from(configString, 'utf8')
+        return configBuffer
       }
       return fs.readFileSync(path, options)
     },


### PR DESCRIPTION
This PR fixes an issue when using AVA with ts-node.

Previously, if you have custom type declaration files (`./src/types/*.d.ts`)
which declare typescript bindings for 3rd party dependencies, these files would
be ignored if you run AVA in ts-node mode.

**Note**: You must keep declaration files inside the `./src/types/` directory
for them to picked up.

#### ts-node mode

AVA with ts-node mode is used when you pass file arguments to `pkg-test`.

For example:

```bash
npm run test ./src/index.spec.ts
```

Previously, there was a bug where any argument would trigger ts-node mode. But
this has been fixed as well.

```bash
npm run test --verbose # does not trigger ts-node mode anymore :)
```