### PR TITLE
fix(tsconfig): make definition files work for npm t [..paths]

### DIFF
--- a/src/config/tsconfig.ts
+++ b/src/config/tsconfig.ts
@@ -15,6 +15,7 @@ const createTSConfig = (): string => {
   for (const filepath of declarationFiles) {
     const moduleName = basename(filepath)
       .replace(/\.d\.ts$/, '')
+      .replace('-', '/')
     paths[moduleName] = [join(SRC_PATH, filepath)]
   }
 


### PR DESCRIPTION
The result of this PR is to change the keys in the `paths` objects that we pass to the typescript compiler so that it can use the type definitions files that are usually located at `src/types/`. 

## What is wrong?

Currently, things specified in the definition files (`.d.ts`) are not being picked up by the typescript compiler when the test command is used with a path specifier passed in. e.g. `npm t src/something/somethingElse/**/*.ts` 

This results in errors from the compiler like `Module '"@mishguru/fanout-helpers"' has no exported member 'getS3Info'` which do not show up when the test command is used without test file paths being specified eg. `npm t`.

## What actually changed?

```
// paths object passed to compiler
{
  ...
  '@mishguru-fanout-helpers': [ 'src/types/@mishguru-fanout-helpers.d.ts' ]
}
```

is now this shape:
```
{
  ...
  '@mishguru/fanout-helpers': [ 'src/types/@mishguru-fanout-helpers.d.ts' ]
}
```

Which means the definition of `@mishguru/fanout-helpers` can be picked up and used. As a result the subset of the test specified can be run instead of failing with an error at compile time.
